### PR TITLE
Fix exporter for API != 6 using the "version" argument

### DIFF
--- a/getdsl.go
+++ b/getdsl.go
@@ -40,6 +40,10 @@ func getDsl() (int, int, int, int) {
 	if err != nil {
 		log.Fatal(err)
 	}
+	if resp.StatusCode == 404 {
+		log.Fatal(resp.Status)
+	}
+
 	body, err := ioutil.ReadAll(resp.Body)
 	if err != nil {
 		log.Fatalln(err)

--- a/getdsl.go
+++ b/getdsl.go
@@ -3,6 +3,7 @@ package main
 import (
 	"bytes"
 	"encoding/json"
+	"fmt"
 	"io/ioutil"
 	"log"
 	"net/http"
@@ -31,7 +32,7 @@ func getDsl() (int, int, int, int) {
 		log.Fatalln(err)
 	}
 	buf := bytes.NewReader(r)
-	req, err := http.NewRequest("POST", mafreebox+"api/v6/rrd/", buf)
+	req, err := http.NewRequest("POST", fmt.Sprintf("%sapi/%s/rrd/", mafreebox, version), buf)
 	if err != nil {
 		log.Fatal(err)
 	}

--- a/getnet.go
+++ b/getnet.go
@@ -3,6 +3,7 @@ package main
 import (
 	"bytes"
 	"encoding/json"
+	"fmt"
 	"io/ioutil"
 	"log"
 	"net/http"
@@ -31,7 +32,7 @@ func getNet() (int, int, int, int, int, int) {
 		log.Fatalln(err)
 	}
 	buf := bytes.NewReader(r)
-	req, err := http.NewRequest("POST", mafreebox+"api/v6/rrd/", buf)
+	req, err := http.NewRequest("POST", fmt.Sprintf("%sapi/%s/rrd/", mafreebox, version), buf)
 	if err != nil {
 		log.Fatal(err)
 	}
@@ -41,8 +42,8 @@ func getNet() (int, int, int, int, int, int) {
 		log.Fatal(err)
 	}
 	if resp.StatusCode == 404 {
-                log.Fatal(resp.Status)
-        }
+		log.Fatal(resp.Status)
+	}
 
 	body, err := ioutil.ReadAll(resp.Body)
 	if err != nil {

--- a/getnet.go
+++ b/getnet.go
@@ -40,6 +40,10 @@ func getNet() (int, int, int, int, int, int) {
 	if err != nil {
 		log.Fatal(err)
 	}
+	if resp.StatusCode == 404 {
+                log.Fatal(resp.Status)
+        }
+
 	body, err := ioutil.ReadAll(resp.Body)
 	if err != nil {
 		log.Fatalln(err)

--- a/getswitch.go
+++ b/getswitch.go
@@ -40,6 +40,10 @@ func getSwitch() (int, int, int, int, int, int, int, int) {
 	if err != nil {
 		log.Fatal(err)
 	}
+        if resp.StatusCode == 404 {
+                log.Fatal(resp.Status)
+        }
+
 	body, err := ioutil.ReadAll(resp.Body)
 	if err != nil {
 		log.Fatalln(err)

--- a/getswitch.go
+++ b/getswitch.go
@@ -3,6 +3,7 @@ package main
 import (
 	"bytes"
 	"encoding/json"
+	"fmt"
 	"io/ioutil"
 	"log"
 	"net/http"
@@ -31,7 +32,7 @@ func getSwitch() (int, int, int, int, int, int, int, int) {
 		log.Fatalln(err)
 	}
 	buf := bytes.NewReader(r)
-	req, err := http.NewRequest("POST", mafreebox+"api/v6/rrd/", buf)
+	req, err := http.NewRequest("POST", fmt.Sprintf("%sapi/%s/rrd/", mafreebox, version), buf)
 	if err != nil {
 		log.Fatal(err)
 	}
@@ -40,9 +41,9 @@ func getSwitch() (int, int, int, int, int, int, int, int) {
 	if err != nil {
 		log.Fatal(err)
 	}
-        if resp.StatusCode == 404 {
-                log.Fatal(resp.Status)
-        }
+	if resp.StatusCode == 404 {
+		log.Fatal(resp.Status)
+	}
 
 	body, err := ioutil.ReadAll(resp.Body)
 	if err != nil {

--- a/gettemp.go
+++ b/gettemp.go
@@ -3,6 +3,7 @@ package main
 import (
 	"bytes"
 	"encoding/json"
+	"fmt"
 	"io/ioutil"
 	"log"
 	"net/http"
@@ -31,7 +32,7 @@ func getTemp() (int, int, int, int, int) {
 		log.Fatalln(err)
 	}
 	buf := bytes.NewReader(r)
-	req, err := http.NewRequest("POST", mafreebox+"api/v6/rrd/", buf)
+	req, err := http.NewRequest("POST", fmt.Sprintf("%sapi/%s/rrd/", mafreebox, version), buf)
 	if err != nil {
 		log.Fatal(err)
 	}
@@ -41,8 +42,8 @@ func getTemp() (int, int, int, int, int) {
 		log.Fatal(err)
 	}
 	if resp.StatusCode == 404 {
-                log.Fatal(resp.Status)
-        }
+		log.Fatal(resp.Status)
+	}
 
 	body, err := ioutil.ReadAll(resp.Body)
 	if err != nil {

--- a/gettemp.go
+++ b/gettemp.go
@@ -40,6 +40,10 @@ func getTemp() (int, int, int, int, int) {
 	if err != nil {
 		log.Fatal(err)
 	}
+	if resp.StatusCode == 404 {
+                log.Fatal(resp.Status)
+        }
+
 	body, err := ioutil.ReadAll(resp.Body)
 	if err != nil {
 		log.Fatalln(err)

--- a/main.go
+++ b/main.go
@@ -4,6 +4,7 @@ import (
 	"flag"
 	"log"
 	"net/http"
+	"strings"
 	"time"
 
 	"github.com/prometheus/client_golang/prometheus"
@@ -38,6 +39,9 @@ func init() {
 func main() {
 	flag.Parse()
 
+	if !strings.HasSuffix(mafreebox, "/") {
+		mafreebox = mafreebox + "/"
+	}
 	// dsl gauge
 	rateUpGauge := promauto.NewGauge(prometheus.GaugeOpts{
 		Name: "freebox_dsl_up_bytes",


### PR DESCRIPTION
I had this issue with my freebox (using v5 API) which got a 404 error on the API. Hence the first commit. Afterwards, I noticed that the "version" argument provided in the main was not used; hence the first commit.

Cheers'!