### PR TITLE
ignore missing RRD metrics for dsl,temp,switch

### DIFF
--- a/getdsl.go
+++ b/getdsl.go
@@ -71,5 +71,9 @@ func getDsl() (int, int, int, int) {
 	case "internal_error":
 		log.Fatalln("Internal error")
 	}
-	return rrdTest.Result.Data[0]["rate_up"], rrdTest.Result.Data[0]["rate_down"], rrdTest.Result.Data[0]["snr_up"], rrdTest.Result.Data[0]["snr_down"]
+	if len(rrdTest.Result.Data) > 0 {
+		return rrdTest.Result.Data[0]["rate_up"], rrdTest.Result.Data[0]["rate_down"], rrdTest.Result.Data[0]["snr_up"], rrdTest.Result.Data[0]["snr_down"]
+	} else {
+		return 0,0,0,0
+	}
 }

--- a/getswitch.go
+++ b/getswitch.go
@@ -71,5 +71,9 @@ func getSwitch() (int, int, int, int, int, int, int, int) {
 	case "internal_error":
 		log.Fatalln("Internal error")
 	}
-	return rrdTest.Result.Data[0]["rx_1"], rrdTest.Result.Data[0]["tx_1"], rrdTest.Result.Data[0]["rx_2"], rrdTest.Result.Data[0]["tx_2"], rrdTest.Result.Data[0]["rx_3"], rrdTest.Result.Data[0]["tx_3"], rrdTest.Result.Data[0]["rx_4"], rrdTest.Result.Data[0]["tx_4"]
+	if len(rrdTest.Result.Data) > 0 {
+		return rrdTest.Result.Data[0]["rx_1"], rrdTest.Result.Data[0]["tx_1"], rrdTest.Result.Data[0]["rx_2"], rrdTest.Result.Data[0]["tx_2"], rrdTest.Result.Data[0]["rx_3"], rrdTest.Result.Data[0]["tx_3"], rrdTest.Result.Data[0]["rx_4"], rrdTest.Result.Data[0]["tx_4"]
+	} else {
+		return 0,0,0,0,0,0,0,0
+	}
 }

--- a/gettemp.go
+++ b/gettemp.go
@@ -71,5 +71,9 @@ func getTemp() (int, int, int, int, int) {
 	case "internal_error":
 		log.Fatalln("Internal error")
 	}
-	return rrdTest.Result.Data[0]["cpum"], rrdTest.Result.Data[0]["cpub"], rrdTest.Result.Data[0]["sw"], rrdTest.Result.Data[0]["hdd"], rrdTest.Result.Data[0]["fan_speed"]
+	if len(rrdTest.Result.Data) > 0 {
+		return rrdTest.Result.Data[0]["cpum"], rrdTest.Result.Data[0]["cpub"], rrdTest.Result.Data[0]["sw"], rrdTest.Result.Data[0]["hdd"], rrdTest.Result.Data[0]["fan_speed"]
+	} else {
+		return 0,0,0,0,0
+	}
 }


### PR DESCRIPTION
Quick workaround for issue [#8](https://github.com/saphoooo/freebox_exporter/issues/8).

Simply ignore missing RRD metrics for dsl,temp,switch (metrics still exists with value 0)

prevent error:

    panic: runtime error: index out of range