### PR TITLE
Optimize docker image size

### DIFF
--- a/Dockerfile-amd64
+++ b/Dockerfile-amd64
@@ -1,21 +1,20 @@
-FROM golang:1.11.5
-
-LABEL maintainer="stephane.beuret@gmail.com"
-
+FROM golang 
 WORKDIR /
-
-RUN go get -d -v golang.org/x/net/html
-
-RUN go get -d -v github.com/prometheus/client_golang/prometheus
-
 COPY . .
+ADD https://github.com/upx/upx/releases/download/v3.95/upx-3.95-amd64_linux.tar.xz /usr/local
+RUN set -x && \
+    apt update && \
+    apt install -y xz-utils && \
+    xz -d -c /usr/local/upx-3.95-amd64_linux.tar.xz | \
+    tar -xOf - upx-3.95-amd64_linux/upx > /bin/upx && \
+    chmod a+x /bin/upx && \
+    go get -d -v . && \
+    CGO_ENABLED=0 GOOS=linux GOARCH=amd64 go build -a -installsuffix cgo -o app . && \
+    strip --strip-unneeded app && \
+    upx app
 
-RUN CGO_ENABLED=0 GOOS=linux GOARCH=amd64 go build -a -installsuffix cgo -o app .
-
-FROM alpine:3.10
-
-RUN apk update && apk add ca-certificates
-
+FROM scratch
+LABEL maintainer="stephane.beuret@gmail.com"
 COPY --from=0 app /
-
+COPY --from=0 /etc/ssl/certs/ca-certificates.crt /etc/ssl/certs/
 ENTRYPOINT ["/app"]


### PR DESCRIPTION
From 13Mo down to 3Mo, by using *FROM scratch* instead of *FROM alpine* + upx compressor + some stuffs

Enjoy! 