### PR TITLE
Add wifi metrics

### DIFF
--- a/gauges.go
+++ b/gauges.go
@@ -213,4 +213,74 @@ var (
 			"firmware_version",
 		},
 	)
+
+	// wifi station labels
+	wifiLabels = []string{
+		"access_point",
+		"hostname",
+		"state",
+	}
+
+	// wifi station signal gauges
+	wifiSignalGauges = promauto.NewGaugeVec(
+		prometheus.GaugeOpts{
+			Name: "freebox_wifi_signal_attenuation_db",
+			Help: "Wifi signal attenuation in decibel",
+		},
+		wifiLabels,
+	)
+
+	// wifi station inactive gauges
+	wifiInactiveGauges = promauto.NewGaugeVec(
+		prometheus.GaugeOpts{
+			Name: "freebox_wifi_inactive_duration_seconds",
+			Help: "Wifi inactive duration in seconds",
+		},
+		wifiLabels,
+	)
+
+	// wifi station conn_duration gauges
+	wifiConnectionDurationGauges = promauto.NewGaugeVec(
+		prometheus.GaugeOpts{
+			Name: "freebox_wifi_connection_duration_seconds",
+			Help: "Wifi connection duration in seconds",
+		},
+		wifiLabels,
+	)
+
+	// wifi station rx_bytes gauges
+	wifiRXBytesGauges = promauto.NewGaugeVec(
+		prometheus.GaugeOpts{
+			Name: "freebox_wifi_rx_bytes",
+			Help: "Wifi received data (from station to Freebox) in bytes",
+		},
+		wifiLabels,
+	)
+
+	// wifi station tx_bytes gauges
+	wifiTXBytesGauges = promauto.NewGaugeVec(
+		prometheus.GaugeOpts{
+			Name: "freebox_wifi_tx_bytes",
+			Help: "Wifi transmitted data (from Freebox to station) in bytes",
+		},
+		wifiLabels,
+	)
+
+	// wifi station rx_rate gauges
+	wifiRXRateGauges = promauto.NewGaugeVec(
+		prometheus.GaugeOpts{
+			Name: "freebox_wifi_rx_rate",
+			Help: "Wifi reception data rate (from station to Freebox) in bytes/seconds",
+		},
+		wifiLabels,
+	)
+
+	// wifi station rx_rate gauges
+	wifiTXRateGauges = promauto.NewGaugeVec(
+		prometheus.GaugeOpts{
+			Name: "freebox_wifi_tx_rate",
+			Help: "Wifi transmission data rate (from Freebox to station) in bytes/seconds",
+		},
+		wifiLabels,
+	)
 )

--- a/getters.go
+++ b/getters.go
@@ -480,3 +480,65 @@ func getSystem(authInf *authInfo, pr *postRequest, xSessionToken *string) (syste
 
 	return systemResp, nil
 }
+
+func getWifi(authInf *authInfo, pr *postRequest, xSessionToken *string) (wifi, error) {
+	client := http.Client{}
+	req, err := http.NewRequest(pr.method, pr.url, nil)
+	if err != nil {
+		return wifi{}, err
+	}
+	req.Header.Add(pr.header, *xSessionToken)
+	resp, err := client.Do(req)
+	if err != nil {
+		return wifi{}, err
+	}
+	if resp.StatusCode == 404 {
+		return wifi{}, errors.New(resp.Status)
+	}
+	body, err := ioutil.ReadAll(resp.Body)
+	if err != nil {
+		return wifi{}, err
+	}
+
+	wifiResp := wifi{}
+	err = json.Unmarshal(body, &wifiResp)
+	if err != nil {
+		if debug {
+			log.Println(string(body))
+		}
+		return wifi{}, err
+	}
+
+	return wifiResp, nil
+}
+
+func getWifiStations(authInf *authInfo, pr *postRequest, xSessionToken *string) (wifiStations, error) {
+	client := http.Client{}
+	req, err := http.NewRequest(pr.method, pr.url, nil)
+	if err != nil {
+		return wifiStations{}, err
+	}
+	req.Header.Add(pr.header, *xSessionToken)
+	resp, err := client.Do(req)
+	if err != nil {
+		return wifiStations{}, err
+	}
+	if resp.StatusCode == 404 {
+		return wifiStations{}, errors.New(resp.Status)
+	}
+	body, err := ioutil.ReadAll(resp.Body)
+	if err != nil {
+		return wifiStations{}, err
+	}
+
+	wifiStationResp := wifiStations{}
+	err = json.Unmarshal(body, &wifiStationResp)
+	if err != nil {
+		if debug {
+			log.Println(string(body))
+		}
+		return wifiStations{}, err
+	}
+
+	return wifiStationResp, nil
+}

--- a/getters_test.go
+++ b/getters_test.go
@@ -569,3 +569,130 @@ func TestGetSystem(t *testing.T) {
 	}
 
 }
+
+func TestGetWifi(t *testing.T) {
+	os.Setenv("FREEBOX_TOKEN", "IOI")
+	defer os.Unsetenv("FREEBOX_TOKEN")
+
+	ts := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		myWifi := wifi{
+			Success: true,
+		}
+		myAP := wifiAccessPoint{
+			Name: "AP1",
+			ID:   0,
+		}
+		myWifi.Result = []wifiAccessPoint{myAP}
+
+		result, _ := json.Marshal(myWifi)
+		fmt.Fprintln(w, string(result))
+	}))
+	defer ts.Close()
+
+	pr := &postRequest{
+		method: "GET",
+		header: "X-Fbx-App-Auth",
+		url:    ts.URL,
+	}
+
+	ai := &authInfo{}
+	mySessionToken := "foobar"
+
+	wifiStats, err := getWifi(ai, pr, &mySessionToken)
+	if err != nil {
+		t.Error("Expected no err, but got", err)
+	}
+
+	if wifiStats.Result[0].Name != "AP1" {
+		t.Error("Expected AP1, but got", wifiStats.Result[0].Name)
+	}
+
+	if wifiStats.Result[0].ID != 0 {
+		t.Error("Expected 0, but got", wifiStats.Result[0].ID)
+	}
+
+}
+
+func TestGetWifiStations(t *testing.T) {
+	os.Setenv("FREEBOX_TOKEN", "IOI")
+	defer os.Unsetenv("FREEBOX_TOKEN")
+
+	ts := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		myWifiStations := wifiStations{
+			Success: true,
+		}
+
+		myStation := wifiStation{
+			Hostname:           "station_host",
+			MAC:                "AA:BB:CC:DD:EE:FF",
+			State:              "authorized",
+			Inactive:           60,
+			RXBytes:            500,
+			TXBytes:            10000,
+			ConnectionDuration: 600,
+			TXRate:             20,
+			RXRate:             5,
+			Signal:             -20,
+		}
+		myWifiStations.Result = []wifiStation{myStation}
+
+		result, _ := json.Marshal(myWifiStations)
+		fmt.Fprintln(w, string(result))
+	}))
+	defer ts.Close()
+
+	pr := &postRequest{
+		method: "GET",
+		header: "X-Fbx-App-Auth",
+		url:    ts.URL,
+	}
+
+	ai := &authInfo{}
+	mySessionToken := "foobar"
+
+	wifiStationsStats, err := getWifiStations(ai, pr, &mySessionToken)
+	if err != nil {
+		t.Error("Expected no err, but got", err)
+	}
+
+	if wifiStationsStats.Result[0].Hostname != "station_host" {
+		t.Error("Expected station_host, but got", wifiStationsStats.Result[0].Hostname)
+	}
+
+	if wifiStationsStats.Result[0].MAC != "AA:BB:CC:DD:EE:FF" {
+		t.Error("Expected AA:BB:CC:DD:EE:FF, but got", wifiStationsStats.Result[0].MAC)
+	}
+
+	if wifiStationsStats.Result[0].State != "authorized" {
+		t.Error("Expected authorized, but got", wifiStationsStats.Result[0].State)
+	}
+
+	if wifiStationsStats.Result[0].Inactive != 60 {
+		t.Error("Expected 60, but got", wifiStationsStats.Result[0].Inactive)
+	}
+
+	if wifiStationsStats.Result[0].RXBytes != 500 {
+		t.Error("Expected 500, but got", wifiStationsStats.Result[0].RXBytes)
+	}
+
+	if wifiStationsStats.Result[0].TXBytes != 10000 {
+		t.Error("Expected 10000, but got", wifiStationsStats.Result[0].TXBytes)
+	}
+
+	if wifiStationsStats.Result[0].ConnectionDuration != 600 {
+		t.Error("Expected 600, but got", wifiStationsStats.Result[0].ConnectionDuration)
+	}
+
+	if wifiStationsStats.Result[0].TXRate != 20 {
+		t.Error("Expected 20, but got", wifiStationsStats.Result[0].TXRate)
+	}
+
+	if wifiStationsStats.Result[0].RXRate != 5 {
+		t.Error("Expected 5, but got", wifiStationsStats.Result[0].RXRate)
+	}
+
+	if wifiStationsStats.Result[0].Signal != -20 {
+		t.Error("Expected -20, but got", wifiStationsStats.Result[0].Signal)
+	}
+
+}

--- a/structs.go
+++ b/structs.go
@@ -191,6 +191,34 @@ type system struct {
 	}
 }
 
+type wifiAccessPoint struct {
+	Name string `json:"name,omitempty"`
+	ID   int    `json:"id,omitempty"`
+}
+
+type wifi struct {
+	Success bool              `json:"success"`
+	Result  []wifiAccessPoint `json:"result,omitempty"`
+}
+
+type wifiStation struct {
+	Hostname           string `json:"hostname,omitempty"`
+	MAC                string `json:"mac,omitempty"`
+	State              string `json:"state,omitempty"`
+	Inactive           int    `json:"inactive,omitempty"`
+	RXBytes            int    `json:"rx_bytes,omitempty"`
+	TXBytes            int    `json:"tx_bytes,omitempty"`
+	ConnectionDuration int    `json:"conn_duration,omitempty"`
+	TXRate             int    `json:"tx_rate,omitempty"`
+	RXRate             int    `json:"rx_rate,omitempty"`
+	Signal             int    `json:"signal,omitempty"`
+}
+
+type wifiStations struct {
+	Success bool          `json:"success"`
+	Result  []wifiStation `json:"result,omitempty"`
+}
+
 type app struct {
 	AppID      string `json:"app_id"`
 	AppName    string `json:"app_name"`


### PR DESCRIPTION
Add wifi metrics by scrapping 2 new freebox endpoints :
* GET /api/v2/wifi/ap/
* GET /api/v2/wifi/ap/{id}/stations/

An example of additional metrics :
```
# HELP freebox_wifi_connection_duration_seconds Wifi connection duration in seconds
# TYPE freebox_wifi_connection_duration_seconds gauge
freebox_wifi_connection_duration_seconds{access_point="2.4G",hostname="host_1",state="authenticated"} 18680
freebox_wifi_connection_duration_seconds{access_point="2.4G",hostname="android-1",state="authenticated"} 2014
# HELP freebox_wifi_inactive_duration_seconds Wifi inactive duration in seconds
# TYPE freebox_wifi_inactive_duration_seconds gauge
freebox_wifi_inactive_duration_seconds{access_point="2.4G",hostname="host_1",state="authenticated"} 86
freebox_wifi_inactive_duration_seconds{access_point="2.4G",hostname="android-1",state="authenticated"} 8
# HELP freebox_wifi_rx_bytes Wifi received data (from station to Freebox) in bytes
# TYPE freebox_wifi_rx_bytes gauge
freebox_wifi_rx_bytes{access_point="2.4G",hostname="host_1",state="authenticated"} 112440
freebox_wifi_rx_bytes{access_point="2.4G",hostname="android-1",state="authenticated"} 178940
# HELP freebox_wifi_rx_rate Wifi reception data rate (from station to Freebox) in bytes/seconds
# TYPE freebox_wifi_rx_rate gauge
freebox_wifi_rx_rate{access_point="2.4G",hostname="host_1",state="authenticated"} 0
freebox_wifi_rx_rate{access_point="2.4G",hostname="android-1",state="authenticated"} 0
# HELP freebox_wifi_signal_attenuation_db Wifi signal attenuation in decibel
# TYPE freebox_wifi_signal_attenuation_db gauge
freebox_wifi_signal_attenuation_db{access_point="2.4G",hostname="host_1",state="authenticated"} -19
freebox_wifi_signal_attenuation_db{access_point="2.4G",hostname="android-1",state="authenticated"} -23
# HELP freebox_wifi_tx_bytes Wifi transmitted data (from Freebox to station) in bytes
# TYPE freebox_wifi_tx_bytes gauge
freebox_wifi_tx_bytes{access_point="2.4G",hostname="host_1",state="authenticated"} 291640
freebox_wifi_tx_bytes{access_point="2.4G",hostname="android-1",state="authenticated"} 221290
# HELP freebox_wifi_tx_rate Wifi transmission data rate (from Freebox to station) in bytes/seconds
# TYPE freebox_wifi_tx_rate gauge
freebox_wifi_tx_rate{access_point="2.4G",hostname="host_1",state="authenticated"} 0
freebox_wifi_tx_rate{access_point="2.4G",hostname="android-1",state="authenticated"} 0
```
