### PR TITLE
Net error

### DIFF
--- a/gauges.go
+++ b/gauges.go
@@ -107,43 +107,6 @@ var (
 		},
 	)
 
-	// RRD switch gauges
-	// as switch database seems to be broken, this one is not used at this time
-	/*
-		rx1Gauge = promauto.NewGauge(prometheus.GaugeOpts{
-			Name: "freebox_switch_rx1_bytes",
-			Help: "Receive rate on port 1 (in byte/s)",
-		})
-		tx1Gauge = promauto.NewGauge(prometheus.GaugeOpts{
-			Name: "freebox_switch_tx1_bytes",
-			Help: "Transmit on port 1 (in byte/s)",
-		})
-		rx2Gauge = promauto.NewGauge(prometheus.GaugeOpts{
-			Name: "freebox_switch_rx2_bytes",
-			Help: "Receive rate on port 2 (in byte/s)",
-		})
-		tx2Gauge = promauto.NewGauge(prometheus.GaugeOpts{
-			Name: "freebox_switch_tx2_bytes",
-			Help: "Transmit on port 2 (in byte/s)",
-		})
-		rx3Gauge = promauto.NewGauge(prometheus.GaugeOpts{
-			Name: "freebox_switch_rx3_bytes",
-			Help: "Receive rate on port 3 (in byte/s)",
-		})
-		tx3Gauge = promauto.NewGauge(prometheus.GaugeOpts{
-			Name: "freebox_switch_tx3_bytes",
-			Help: "Transmit on port 3 (in byte/s)",
-		})
-		rx4Gauge = promauto.NewGauge(prometheus.GaugeOpts{
-			Name: "freebox_switch_rx4_bytes",
-			Help: "Receive rate on port 4 (in byte/s)",
-		})
-		tx4Gauge = promauto.NewGauge(prometheus.GaugeOpts{
-			Name: "freebox_switch_tx4_bytes",
-			Help: "Transmit on port 4 (in byte/s)",
-		})
-	*/
-
 	// RRD net gauges
 	bwUpGauge = promauto.NewGauge(prometheus.GaugeOpts{
 		Name: "freebox_net_bw_up_bytes",

--- a/getters.go
+++ b/getters.go
@@ -276,7 +276,7 @@ func getNet(authInf *authInfo, pr *postRequest, xSessionToken *string) ([]int, e
 	}
 	rrdTest := rrd{}
 	// debug
-	fmt.Println(body)
+	fmt.Printf("Debug is turned on.\n><)))°> Trace\n%vEnd of trace <°)))><\n\n", string(body))
 	// end debug
 	err = json.Unmarshal(body, &rrdTest)
 	if err != nil {

--- a/getters.go
+++ b/getters.go
@@ -107,7 +107,7 @@ func getConnectionXdsl(authInf *authInfo, pr *postRequest, xSessionToken *string
 }
 
 // getDsl get dsl statistics
-func getDsl(authInf *authInfo, pr *postRequest, xSessionToken *string) ([]int, error) {
+func getDsl(authInf *authInfo, pr *postRequest, xSessionToken *string) ([]uint64, error) {
 	d := &database{
 		DB:        "dsl",
 		Fields:    []string{"rate_up", "rate_down", "snr_up", "snr_down"},
@@ -117,29 +117,29 @@ func getDsl(authInf *authInfo, pr *postRequest, xSessionToken *string) ([]int, e
 
 	freeboxToken, err := setFreeboxToken(authInf, xSessionToken)
 	if err != nil {
-		return []int{}, err
+		return []uint64{}, err
 	}
 	client := http.Client{}
 	r, err := json.Marshal(*d)
 	if err != nil {
-		return []int{}, err
+		return []uint64{}, err
 	}
 	buf := bytes.NewReader(r)
 	req, err := http.NewRequest(pr.method, pr.url, buf)
 	if err != nil {
-		return []int{}, err
+		return []uint64{}, err
 	}
 	req.Header.Add(pr.header, *xSessionToken)
 	resp, err := client.Do(req)
 	if err != nil {
-		return []int{}, err
+		return []uint64{}, err
 	}
 	if resp.StatusCode == 404 {
-		return []int{}, errors.New(resp.Status)
+		return []uint64{}, errors.New(resp.Status)
 	}
 	body, err := ioutil.ReadAll(resp.Body)
 	if err != nil {
-		return []int{}, err
+		return []uint64{}, err
 	}
 	rrdTest := rrd{}
 	err = json.Unmarshal(body, &rrdTest)
@@ -147,13 +147,13 @@ func getDsl(authInf *authInfo, pr *postRequest, xSessionToken *string) ([]int, e
 		if debug {
 			log.Println(string(body))
 		}
-		return []int{}, err
+		return []uint64{}, err
 	}
 
 	if rrdTest.ErrorCode == "auth_required" {
 		*xSessionToken, err = getSessToken(freeboxToken, authInf, xSessionToken)
 		if err != nil {
-			return []int{}, err
+			return []uint64{}, err
 		}
 	}
 
@@ -161,19 +161,19 @@ func getDsl(authInf *authInfo, pr *postRequest, xSessionToken *string) ([]int, e
 		if rrdTest.status().Error() == "Unknown return code from the API" {
 			fmt.Println("getDsl")
 		}
-		return []int{}, rrdTest.status()
+		return []uint64{}, rrdTest.status()
 	}
 
 	if len(rrdTest.Result.Data) == 0 {
-		return []int{}, nil
+		return []uint64{}, nil
 	}
 
-	result := []int{rrdTest.Result.Data[0]["rate_up"], rrdTest.Result.Data[0]["rate_down"], rrdTest.Result.Data[0]["snr_up"], rrdTest.Result.Data[0]["snr_down"]}
+	result := []uint64{rrdTest.Result.Data[0]["rate_up"], rrdTest.Result.Data[0]["rate_down"], rrdTest.Result.Data[0]["snr_up"], rrdTest.Result.Data[0]["snr_down"]}
 	return result, nil
 }
 
 // getTemp get temp statistics
-func getTemp(authInf *authInfo, pr *postRequest, xSessionToken *string) ([]int, error) {
+func getTemp(authInf *authInfo, pr *postRequest, xSessionToken *string) ([]uint64, error) {
 	d := &database{
 		DB:        "temp",
 		Fields:    []string{"cpum", "cpub", "sw", "hdd", "fan_speed"},
@@ -183,30 +183,30 @@ func getTemp(authInf *authInfo, pr *postRequest, xSessionToken *string) ([]int, 
 
 	freeboxToken, err := setFreeboxToken(authInf, xSessionToken)
 	if err != nil {
-		return []int{}, err
+		return []uint64{}, err
 	}
 
 	client := http.Client{}
 	r, err := json.Marshal(*d)
 	if err != nil {
-		return []int{}, err
+		return []uint64{}, err
 	}
 	buf := bytes.NewReader(r)
 	req, err := http.NewRequest(pr.method, fmt.Sprintf(pr.url), buf)
 	if err != nil {
-		return []int{}, err
+		return []uint64{}, err
 	}
 	req.Header.Add(pr.header, *xSessionToken)
 	resp, err := client.Do(req)
 	if err != nil {
-		return []int{}, err
+		return []uint64{}, err
 	}
 	if resp.StatusCode == 404 {
-		return []int{}, errors.New(resp.Status)
+		return []uint64{}, errors.New(resp.Status)
 	}
 	body, err := ioutil.ReadAll(resp.Body)
 	if err != nil {
-		return []int{}, err
+		return []uint64{}, err
 	}
 	rrdTest := rrd{}
 	err = json.Unmarshal(body, &rrdTest)
@@ -214,13 +214,13 @@ func getTemp(authInf *authInfo, pr *postRequest, xSessionToken *string) ([]int, 
 		if debug {
 			log.Println(string(body))
 		}
-		return []int{}, err
+		return []uint64{}, err
 	}
 
 	if rrdTest.ErrorCode == "auth_required" {
 		*xSessionToken, err = getSessToken(freeboxToken, authInf, xSessionToken)
 		if err != nil {
-			return []int{}, err
+			return []uint64{}, err
 		}
 	}
 
@@ -228,18 +228,18 @@ func getTemp(authInf *authInfo, pr *postRequest, xSessionToken *string) ([]int, 
 		if rrdTest.status().Error() == "Unknown return code from the API" {
 			fmt.Println("getTemp")
 		}
-		return []int{}, rrdTest.status()
+		return []uint64{}, rrdTest.status()
 	}
 
 	if len(rrdTest.Result.Data) == 0 {
-		return []int{}, nil
+		return []uint64{}, nil
 	}
 
-	return []int{rrdTest.Result.Data[0]["cpum"], rrdTest.Result.Data[0]["cpub"], rrdTest.Result.Data[0]["sw"], rrdTest.Result.Data[0]["hdd"], rrdTest.Result.Data[0]["fan_speed"]}, nil
+	return []uint64{rrdTest.Result.Data[0]["cpum"], rrdTest.Result.Data[0]["cpub"], rrdTest.Result.Data[0]["sw"], rrdTest.Result.Data[0]["hdd"], rrdTest.Result.Data[0]["fan_speed"]}, nil
 }
 
 // getNet get net statistics
-func getNet(authInf *authInfo, pr *postRequest, xSessionToken *string) ([]int, error) {
+func getNet(authInf *authInfo, pr *postRequest, xSessionToken *string) ([]uint64, error) {
 	d := &database{
 		DB:        "net",
 		Fields:    []string{"bw_up", "bw_down", "rate_up", "rate_down", "vpn_rate_up", "vpn_rate_down"},
@@ -249,47 +249,44 @@ func getNet(authInf *authInfo, pr *postRequest, xSessionToken *string) ([]int, e
 
 	freeboxToken, err := setFreeboxToken(authInf, xSessionToken)
 	if err != nil {
-		return []int{}, err
+		return []uint64{}, err
 	}
 
 	client := http.Client{}
 	r, err := json.Marshal(*d)
 	if err != nil {
-		return []int{}, err
+		return []uint64{}, err
 	}
 	buf := bytes.NewReader(r)
 	req, err := http.NewRequest(pr.method, pr.url, buf)
 	if err != nil {
-		return []int{}, err
+		return []uint64{}, err
 	}
 	req.Header.Add(pr.header, *xSessionToken)
 	resp, err := client.Do(req)
 	if err != nil {
-		return []int{}, err
+		return []uint64{}, err
 	}
 	if resp.StatusCode == 404 {
-		return []int{}, errors.New(resp.Status)
+		return []uint64{}, errors.New(resp.Status)
 	}
 	body, err := ioutil.ReadAll(resp.Body)
 	if err != nil {
-		return []int{}, err
+		return []uint64{}, err
 	}
 	rrdTest := rrd{}
-	// debug
-	fmt.Printf("Debug is turned on.\n><)))°> Trace\n%vEnd of trace <°)))><\n\n", string(body))
-	// end debug
 	err = json.Unmarshal(body, &rrdTest)
 	if err != nil {
 		if debug {
 			log.Println(string(body))
 		}
-		return []int{}, err
+		return []uint64{}, err
 	}
 
 	if rrdTest.ErrorCode == "auth_required" {
 		*xSessionToken, err = getSessToken(freeboxToken, authInf, xSessionToken)
 		if err != nil {
-			return []int{}, err
+			return []uint64{}, err
 		}
 	}
 
@@ -297,18 +294,18 @@ func getNet(authInf *authInfo, pr *postRequest, xSessionToken *string) ([]int, e
 		if rrdTest.status().Error() == "Unknown return code from the API" {
 			fmt.Println("getNet")
 		}
-		return []int{}, rrdTest.status()
+		return []uint64{}, rrdTest.status()
 	}
 
 	if len(rrdTest.Result.Data) == 0 {
-		return []int{}, nil
+		return []uint64{}, nil
 	}
 
-	return []int{rrdTest.Result.Data[0]["bw_up"], rrdTest.Result.Data[0]["bw_down"], rrdTest.Result.Data[0]["rate_up"], rrdTest.Result.Data[0]["rate_down"], rrdTest.Result.Data[0]["vpn_rate_up"], rrdTest.Result.Data[0]["vpn_rate_down"]}, nil
+	return []uint64{rrdTest.Result.Data[0]["bw_up"], rrdTest.Result.Data[0]["bw_down"], rrdTest.Result.Data[0]["rate_up"], rrdTest.Result.Data[0]["rate_down"], rrdTest.Result.Data[0]["vpn_rate_up"], rrdTest.Result.Data[0]["vpn_rate_down"]}, nil
 }
 
 // getSwitch get switch statistics
-func getSwitch(authInf *authInfo, pr *postRequest, xSessionToken *string) ([]int, error) {
+func getSwitch(authInf *authInfo, pr *postRequest, xSessionToken *string) ([]uint64, error) {
 	d := &database{
 		DB:        "switch",
 		Fields:    []string{"rx_1", "tx_1", "rx_2", "tx_2", "rx_3", "tx_3", "rx_4", "tx_4"},
@@ -318,30 +315,30 @@ func getSwitch(authInf *authInfo, pr *postRequest, xSessionToken *string) ([]int
 
 	freeboxToken, err := setFreeboxToken(authInf, xSessionToken)
 	if err != nil {
-		return []int{}, err
+		return []uint64{}, err
 	}
 
 	client := http.Client{}
 	r, err := json.Marshal(*d)
 	if err != nil {
-		return []int{}, err
+		return []uint64{}, err
 	}
 	buf := bytes.NewReader(r)
 	req, err := http.NewRequest(pr.method, pr.url, buf)
 	if err != nil {
-		return []int{}, err
+		return []uint64{}, err
 	}
 	req.Header.Add(pr.header, *xSessionToken)
 	resp, err := client.Do(req)
 	if err != nil {
-		return []int{}, err
+		return []uint64{}, err
 	}
 	if resp.StatusCode == 404 {
-		return []int{}, errors.New(resp.Status)
+		return []uint64{}, errors.New(resp.Status)
 	}
 	body, err := ioutil.ReadAll(resp.Body)
 	if err != nil {
-		return []int{}, err
+		return []uint64{}, err
 	}
 	rrdTest := rrd{}
 	err = json.Unmarshal(body, &rrdTest)
@@ -349,13 +346,13 @@ func getSwitch(authInf *authInfo, pr *postRequest, xSessionToken *string) ([]int
 		if debug {
 			log.Println(string(body))
 		}
-		return []int{}, err
+		return []uint64{}, err
 	}
 
 	if rrdTest.ErrorCode == "auth_required" {
 		*xSessionToken, err = getSessToken(freeboxToken, authInf, xSessionToken)
 		if err != nil {
-			return []int{}, err
+			return []uint64{}, err
 		}
 	}
 
@@ -363,14 +360,14 @@ func getSwitch(authInf *authInfo, pr *postRequest, xSessionToken *string) ([]int
 		if rrdTest.status().Error() == "Unknown return code from the API" {
 			fmt.Println("getSwitch")
 		}
-		return []int{}, rrdTest.status()
+		return []uint64{}, rrdTest.status()
 	}
 
 	if len(rrdTest.Result.Data) == 0 {
-		return []int{}, nil
+		return []uint64{}, nil
 	}
 
-	return []int{rrdTest.Result.Data[0]["rx_1"], rrdTest.Result.Data[0]["tx_1"], rrdTest.Result.Data[0]["rx_2"], rrdTest.Result.Data[0]["tx_2"], rrdTest.Result.Data[0]["rx_3"], rrdTest.Result.Data[0]["tx_3"], rrdTest.Result.Data[0]["rx_4"], rrdTest.Result.Data[0]["tx_4"]}, nil
+	return []uint64{rrdTest.Result.Data[0]["rx_1"], rrdTest.Result.Data[0]["tx_1"], rrdTest.Result.Data[0]["rx_2"], rrdTest.Result.Data[0]["tx_2"], rrdTest.Result.Data[0]["rx_3"], rrdTest.Result.Data[0]["tx_3"], rrdTest.Result.Data[0]["rx_4"], rrdTest.Result.Data[0]["tx_4"]}, nil
 }
 
 // getLan get lan statistics

--- a/getters.go
+++ b/getters.go
@@ -275,6 +275,9 @@ func getNet(authInf *authInfo, pr *postRequest, xSessionToken *string) ([]int, e
 		return []int{}, err
 	}
 	rrdTest := rrd{}
+	// debug
+	fmt.Println(body)
+	// end debug
 	err = json.Unmarshal(body, &rrdTest)
 	if err != nil {
 		if debug {

--- a/getters_test.go
+++ b/getters_test.go
@@ -92,7 +92,7 @@ func TestGetDsl(t *testing.T) {
 			myRRD := rrd{
 				Success: true,
 			}
-			myRRD.Result.Data = []map[string]int{
+			myRRD.Result.Data = []map[string]uint64{
 				{
 					"rate_up":   12,
 					"rate_down": 34,
@@ -179,7 +179,7 @@ func TestGetTemp(t *testing.T) {
 			myRRD := rrd{
 				Success: true,
 			}
-			myRRD.Result.Data = []map[string]int{
+			myRRD.Result.Data = []map[string]uint64{
 				{
 					"cpum":      01,
 					"cpub":      02,
@@ -267,7 +267,7 @@ func TestGetNet(t *testing.T) {
 			myRRD := rrd{
 				Success: true,
 			}
-			myRRD.Result.Data = []map[string]int{
+			myRRD.Result.Data = []map[string]uint64{
 				{
 					"bw_up":         12500000000,
 					"bw_down":       12500000000,
@@ -356,7 +356,7 @@ func TestGetSwitch(t *testing.T) {
 			myRRD := rrd{
 				Success: true,
 			}
-			myRRD.Result.Data = []map[string]int{
+			myRRD.Result.Data = []map[string]uint64{
 				{
 					"rx_1": 01,
 					"tx_1": 11,

--- a/getters_test.go
+++ b/getters_test.go
@@ -7,6 +7,7 @@ import (
 	"net/http"
 	"net/http/httptest"
 	"os"
+	"reflect"
 	"strings"
 	"testing"
 )
@@ -268,12 +269,12 @@ func TestGetNet(t *testing.T) {
 			}
 			myRRD.Result.Data = []map[string]int{
 				{
-					"bw_up":         01,
-					"bw_down":       02,
-					"rate_up":       03,
-					"rate_down":     04,
-					"vpn_rate_up":   05,
-					"vpn_rate_down": 06,
+					"bw_up":         12500000000,
+					"bw_down":       12500000000,
+					"rate_up":       12500000000,
+					"rate_down":     12500000000,
+					"vpn_rate_up":   12500000000,
+					"vpn_rate_down": 12500000000,
 				},
 			}
 			result, _ := json.Marshal(myRRD)
@@ -321,7 +322,7 @@ func TestGetNet(t *testing.T) {
 		t.Error("Expected no err, but go", err)
 	}
 
-	if getNetResult[0] != 01 || getNetResult[1] != 02 || getNetResult[2] != 03 || getNetResult[3] != 04 || getNetResult[4] != 05 || getNetResult[5] != 06 {
+	if getNetResult[0] != 12500000000 || getNetResult[1] != 12500000000 || getNetResult[2] != 12500000000 || getNetResult[3] != 12500000000 || getNetResult[4] != 12500000000 || getNetResult[5] != 12500000000 {
 		t.Errorf("Expected 01 02 03 04 05 06, but got %v %v %v %v %v %v\n", getNetResult[0], getNetResult[1], getNetResult[2], getNetResult[3], getNetResult[4], getNetResult[5])
 	}
 
@@ -695,4 +696,32 @@ func TestGetWifiStations(t *testing.T) {
 		t.Error("Expected -20, but got", wifiStationsStats.Result[0].Signal)
 	}
 
+}
+
+func Test_getNet(t *testing.T) {
+	type args struct {
+		authInf       *authInfo
+		pr            *postRequest
+		xSessionToken *string
+	}
+	tests := []struct {
+		name    string
+		args    args
+		want    []int
+		wantErr bool
+	}{
+		// TODO: Add test cases.
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got, err := getNet(tt.args.authInf, tt.args.pr, tt.args.xSessionToken)
+			if (err != nil) != tt.wantErr {
+				t.Errorf("getNet() error = %v, wantErr %v", err, tt.wantErr)
+				return
+			}
+			if !reflect.DeepEqual(got, tt.want) {
+				t.Errorf("getNet() = %v, want %v", got, tt.want)
+			}
+		})
+	}
 }

--- a/structs.go
+++ b/structs.go
@@ -58,9 +58,9 @@ type rrd struct {
 	Success bool   `json:"success"`
 	Msg     string `json:"msg,omitempty"`
 	Result  struct {
-		DateStart int              `json:"date_start,omitempty"`
-		DateEnd   int              `json:"date_end,omitempty"`
-		Data      []map[string]int `json:"data,omitempty"`
+		DateStart int                 `json:"date_start,omitempty"`
+		DateEnd   int                 `json:"date_end,omitempty"`
+		Data      []map[string]uint64 `json:"data,omitempty"`
 	} `json:"result"`
 	ErrorCode string `json:"error_code"`
 }

--- a/structs.go
+++ b/structs.go
@@ -76,48 +76,48 @@ type connectionXdsl struct {
 			Uptime     int    `json:"uptime"`
 		} `json:"status"`
 		Down struct {
-			Attn       int  `json:"attn"`
-			Attn10     int  `json:"attn_10"`
-			Crc        int  `json:"crc"`
-			Es         int  `json:"es"`
-			Fec        int  `json:"fec"`
-			Ginp       bool `json:"ginp"`
-			Hec        int  `json:"hec"`
-			Maxrate    uint64  `json:"maxrate"`
-			Nitro      bool `json:"nitro"`
-			Phyr       bool `json:"phyr"`
-			Rate       int  `json:"rate"`
-			RtxC       int  `json:"rtx_c,omitempty"`
-			RtxTx      int  `json:"rtx_tx,omitempty"`
-			RtxUc      int  `json:"rtx_uc,omitempty"`
-			Rxmt       int  `json:"rxmt"`
-			RxmtCorr   int  `json:"rxmt_corr"`
-			RxmtUncorr int  `json:"rxmt_uncorr"`
-			Ses        int  `json:"ses"`
-			Snr        int  `json:"snr"`
-			Snr10      int  `json:"snr_10"`
+			Attn       int    `json:"attn"`
+			Attn10     int    `json:"attn_10"`
+			Crc        int    `json:"crc"`
+			Es         int    `json:"es"`
+			Fec        int    `json:"fec"`
+			Ginp       bool   `json:"ginp"`
+			Hec        int    `json:"hec"`
+			Maxrate    uint64 `json:"maxrate"`
+			Nitro      bool   `json:"nitro"`
+			Phyr       bool   `json:"phyr"`
+			Rate       int    `json:"rate"`
+			RtxC       int    `json:"rtx_c,omitempty"`
+			RtxTx      int    `json:"rtx_tx,omitempty"`
+			RtxUc      int    `json:"rtx_uc,omitempty"`
+			Rxmt       int    `json:"rxmt"`
+			RxmtCorr   int    `json:"rxmt_corr"`
+			RxmtUncorr int    `json:"rxmt_uncorr"`
+			Ses        int    `json:"ses"`
+			Snr        int    `json:"snr"`
+			Snr10      int    `json:"snr_10"`
 		} `json:"down"`
 		Up struct {
-			Attn       int  `json:"attn"`
-			Attn10     int  `json:"attn_10"`
-			Crc        int  `json:"crc"`
-			Es         int  `json:"es"`
-			Fec        int  `json:"fec"`
-			Ginp       bool `json:"ginp"`
-			Hec        int  `json:"hec"`
-			Maxrate    uint64  `json:"maxrate"`
-			Nitro      bool `json:"nitro"`
-			Phyr       bool `json:"phyr"`
-			Rate       uint64  `json:"rate"`
-			RtxC       int  `json:"rtx_c,omitempty"`
-			RtxTx      int  `json:"rtx_tx,omitempty"`
-			RtxUc      int  `json:"rtx_uc,omitempty"`
-			Rxmt       int  `json:"rxmt"`
-			RxmtCorr   int  `json:"rxmt_corr"`
-			RxmtUncorr int  `json:"rxmt_uncorr"`
-			Ses        int  `json:"ses"`
-			Snr        int  `json:"snr"`
-			Snr10      int  `json:"snr_10"`
+			Attn       int    `json:"attn"`
+			Attn10     int    `json:"attn_10"`
+			Crc        int    `json:"crc"`
+			Es         int    `json:"es"`
+			Fec        int    `json:"fec"`
+			Ginp       bool   `json:"ginp"`
+			Hec        int    `json:"hec"`
+			Maxrate    uint64 `json:"maxrate"`
+			Nitro      bool   `json:"nitro"`
+			Phyr       bool   `json:"phyr"`
+			Rate       uint64 `json:"rate"`
+			RtxC       int    `json:"rtx_c,omitempty"`
+			RtxTx      int    `json:"rtx_tx,omitempty"`
+			RtxUc      int    `json:"rtx_uc,omitempty"`
+			Rxmt       int    `json:"rxmt"`
+			RxmtCorr   int    `json:"rxmt_corr"`
+			RxmtUncorr int    `json:"rxmt_uncorr"`
+			Ses        int    `json:"ses"`
+			Snr        int    `json:"snr"`
+			Snr10      int    `json:"snr_10"`
 		} `json:"up"`
 	}
 }
@@ -150,7 +150,7 @@ type freeplugMember struct {
 	HasNetwork    bool   `json:"has_network"`
 	EthSpeed      int    `json:"eth_speed"`
 	Inative       int    `json:"inactive"`
-	NetId         string `json:"net_id"`
+	NetID         string `json:"net_id"`
 	RxRate        int    `json:"rx_rate"`
 	TxRate        int    `json:"tx_rate"`
 }

--- a/structs.go
+++ b/structs.go
@@ -65,6 +65,7 @@ type rrd struct {
 	ErrorCode string `json:"error_code"`
 }
 
+// https://dev.freebox.fr/sdk/os/connection/
 type connectionXdsl struct {
 	Success bool `json:"success"`
 	Result  struct {
@@ -82,7 +83,7 @@ type connectionXdsl struct {
 			Fec        int  `json:"fec"`
 			Ginp       bool `json:"ginp"`
 			Hec        int  `json:"hec"`
-			Maxrate    int  `json:"maxrate"`
+			Maxrate    uint64  `json:"maxrate"`
 			Nitro      bool `json:"nitro"`
 			Phyr       bool `json:"phyr"`
 			Rate       int  `json:"rate"`
@@ -104,10 +105,10 @@ type connectionXdsl struct {
 			Fec        int  `json:"fec"`
 			Ginp       bool `json:"ginp"`
 			Hec        int  `json:"hec"`
-			Maxrate    int  `json:"maxrate"`
+			Maxrate    uint64  `json:"maxrate"`
 			Nitro      bool `json:"nitro"`
 			Phyr       bool `json:"phyr"`
-			Rate       int  `json:"rate"`
+			Rate       uint64  `json:"rate"`
 			RtxC       int  `json:"rtx_c,omitempty"`
 			RtxTx      int  `json:"rtx_tx,omitempty"`
 			RtxUc      int  `json:"rtx_uc,omitempty"`
@@ -129,6 +130,7 @@ type database struct {
 	Fields    []string `json:"fields"`
 }
 
+// https://dev.freebox.fr/sdk/os/freeplug/
 type freeplug struct {
 	Success bool              `json:"success"`
 	Result  []freeplugNetwork `json:"result"`
@@ -153,6 +155,7 @@ type freeplugMember struct {
 	TxRate        int    `json:"tx_rate"`
 }
 
+// https://dev.freebox.fr/sdk/os/lan/
 type lanHost struct {
 	Reachable   bool   `json:"reachable,omitempty"`
 	PrimaryName string `json:"primary_name,omitempty"`
@@ -170,6 +173,7 @@ type idNameValue struct {
 	Value int    `json:"value,omitempty"`
 }
 
+// https://dev.freebox.fr/sdk/os/system/
 type system struct {
 	Success bool `json:"success"`
 	Result  struct {
@@ -191,6 +195,7 @@ type system struct {
 	}
 }
 
+// https://dev.freebox.fr/sdk/os/wifi/
 type wifiAccessPoint struct {
 	Name string `json:"name,omitempty"`
 	ID   int    `json:"id,omitempty"`


### PR DESCRIPTION
Use int64 instead of int for RDD, because some return value are bigger than int on arm.