### PR TITLE
Fix int data type to support high speeds

### DIFF
--- a/getters_test.go
+++ b/getters_test.go
@@ -629,9 +629,9 @@ func TestGetWifiStations(t *testing.T) {
 			State:              "authorized",
 			Inactive:           60,
 			RXBytes:            500,
-			TXBytes:            10000,
+			TXBytes:            2280000000,
 			ConnectionDuration: 600,
-			TXRate:             20,
+			TXRate:             4260000000,
 			RXRate:             5,
 			Signal:             -20,
 		}

--- a/structs.go
+++ b/structs.go
@@ -151,8 +151,8 @@ type freeplugMember struct {
 	EthSpeed      int    `json:"eth_speed"`
 	Inative       int    `json:"inactive"`
 	NetID         string `json:"net_id"`
-	RxRate        int    `json:"rx_rate"`
-	TxRate        int    `json:"tx_rate"`
+	RxRate        int64  `json:"rx_rate"`
+	TxRate        int64  `json:"tx_rate"`
 }
 
 // https://dev.freebox.fr/sdk/os/lan/
@@ -217,11 +217,11 @@ type wifiStation struct {
 	MAC                string `json:"mac,omitempty"`
 	State              string `json:"state,omitempty"`
 	Inactive           int    `json:"inactive,omitempty"`
-	RXBytes            int    `json:"rx_bytes,omitempty"`
-	TXBytes            int    `json:"tx_bytes,omitempty"`
+	RXBytes            int64   `json:"rx_bytes,omitempty"`
+	TXBytes            int64   `json:"tx_bytes,omitempty"`
 	ConnectionDuration int    `json:"conn_duration,omitempty"`
-	TXRate             int    `json:"tx_rate,omitempty"`
-	RXRate             int    `json:"rx_rate,omitempty"`
+	TXRate             int64   `json:"tx_rate,omitempty"`
+	RXRate             int64   `json:"rx_rate,omitempty"`
 	Signal             int    `json:"signal,omitempty"`
 }
 
@@ -262,9 +262,9 @@ type postRequest struct {
 type vpnServer struct {
 	Success bool `json:"success"`
 	Result  []struct {
-		RxBytes       int    `json:"rx_bytes,omitempty"`
+		RxBytes       int64  `json:"rx_bytes,omitempty"`
 		Authenticated bool   `json:"authenticated,omitempty"`
-		TxBytes       int    `json:"tx_bytes,omitempty"`
+		TxBytes       int64  `json:"tx_bytes,omitempty"`
 		User          string `json:"user,omitempty"`
 		ID            string `json:"id,omitempty"`
 		Vpn           string `json:"vpn,omitempty"`


### PR DESCRIPTION
Wifi RX/TX values are not supported if to high : 

```
2021/08/22 09:44:50 An error occured with Wifi station metrics: json: cannot unmarshal number 2280000000 into Go struct field wifiStation.result.tx_bytes of type int
```

Change `int` into `int64`